### PR TITLE
Add prefix option for executable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Now you're ready to start a transactor and load up your schemas and initial data
     $ lein datomic start &
     $ lein datomic initialize   #this requires a running transactor
 
+### Optional Configuration
+
+* `:exe-prefix "datomic-"` (Mac/Homebrew specific): Prefix datomic executable names with the given string
+
 ## License
 
 Copyright © 2012 Wayne Rittimann, Jr.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-datomic "0.2.0"
+(defproject lein-datomic "0.2.1"
   :description "Leiningen plugin for various Datomic tasks."
   :url "http://github.com/johnwayner/lein-datomic"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/datomic.clj
+++ b/src/leiningen/datomic.clj
@@ -4,11 +4,19 @@
   (:import java.io.File))
 
 
+(defn- prefix-str
+  "Prefixes a string"
+  [s prefix]
+  (if (nil? prefix)
+    s
+    (str prefix s)))
+
 (defn start
   "Start a Datomic instance as specified in project.clj."
-  [root {:keys [install-location config db-uri test-data]}]
+  [root {:keys [install-location config db-uri test-data exe-prefix]}]
   (if config 
-    (let [p (sh/proc "bin/transactor" (str root File/separator config)
+    (let [p (sh/proc (str "bin/" (prefix-str "transactor" exe-prefix))
+                     (str root File/separator config)
                      :dir install-location)]
       (while true (try
                     (sh/stream-to-out p :out)


### PR DESCRIPTION
Homebrew installs of datomic have "datomic-" prefixed to all executable names. This config option adds support for that.
