### PR TITLE
More robust reading of schema files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject lein-datomic "0.2.0"
+(defproject jalehman/lein-datomic "0.2.0"
   :description "Leiningen plugin for various Datomic tasks."
-  :url "http://github.com/johnwayner/lein-datomic"
+  :url "http://github.com/jalehman/lein-datomic"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject lein-datomic "0.2.0"
   :description "Leiningen plugin for various Datomic tasks."
-  :url "http://github.com/jalehman/lein-datomic"
+  :url "http://github.com/johnwayner/lein-datomic"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jalehman/lein-datomic "0.2.0"
+(defproject lein-datomic "0.2.0"
   :description "Leiningen plugin for various Datomic tasks."
   :url "http://github.com/jalehman/lein-datomic"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/datomic.clj
+++ b/src/leiningen/datomic.clj
@@ -7,7 +7,7 @@
 (defn start
   "Start a Datomic instance as specified in project.clj."
   [root {:keys [install-location config db-uri test-data]}]
-  (if config 
+  (if config
     (let [p (sh/proc "bin/transactor" (str root File/separator config)
                      :dir install-location)]
       (while true (try
@@ -23,7 +23,7 @@
      (string? schemas) (vector schemas)
      (vector? schemas) (apply concat
                               (for [dir-pair (partition 2 schemas)]
-                                (let [[base-dir file-names] dir-pair 
+                                (let [[base-dir file-names] dir-pair
                                       schema-dir (File. (str (:root project)
                                                              File/separator base-dir))]
                                   (for [file-name file-names]
@@ -42,9 +42,8 @@
              ~@(for [schema-file (schema-paths project)]
                  `(do
                     (println ~(str "Loading " schema-file "..."))
-                    (datomic.api/transact
-                     ~conn
-                     (read-string (slurp ~schema-file))))))
+                    (doseq [txd# (datomic.Util/readAll (clojure.java.io/reader ~schema-file))]
+                      (datomic.api/transact ~conn txd#)))))
 
            (catch Exception e#
              (.printStackTrace e#))


### PR DESCRIPTION
In the [day-of-datomic](https://github.com/Datomic/day-of-datomic) they use `datomic.Util/readAll` [here](https://github.com/Datomic/day-of-datomic/blob/master/src/datomic/samples/io.clj#L18) to read EDN files -- this has the added benefit of allowing multiple EDN vectors within the same file to be read. This PR adds that functionality.
